### PR TITLE
fix: include license in project metadata

### DIFF
--- a/build_oui.py
+++ b/build_oui.py
@@ -13,6 +13,7 @@ def build(setup_kwargs: dict[str, Any]) -> None:
     """Build the OUI data."""
     setup_kwargs["maintainer"] = "Bluetooth Devices"
     setup_kwargs["maintainer_email"] = "bluetooth@koston.org"
+    setup_kwargs["license"] = "MIT"
     setuptools.setup(
         **setup_kwargs,
         long_description_content_type="text/markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "aiooui"
 version = "0.1.6"
 description = "Async OUI lookups"
 authors = ["J. Nick Koston <nick@koston.org>"]
+license = "MIT"
 readme = "README.md"
 repository = "https://github.com/bluetooth-devices/aiooui"
 classifiers = [
@@ -11,7 +12,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
-    "License :: OSI Approved :: MIT License",
 ]
 packages = [
     { include = "aiooui", from = "src" },


### PR DESCRIPTION
Followup to #8. For some reason neither the `license` attribute nor the classifier is passed from poetry to setuptools. Add the license attribute to the build script itself.