### PR TITLE
chore: ignore wrong commit message for semantic releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ build_command = "pip install poetry && poetry build"
 exclude_commit_patterns = [
     "chore*",
     "ci*",
+    "Remove.*",
 ]
 
 [tool.semantic_release.changelog.environment]


### PR DESCRIPTION
Ignore the commit messages from https://github.com/Bluetooth-Devices/aiooui/pull/22.