### PR TITLE
chore: remove unused type ignore in build_oui

### DIFF
--- a/build_oui.py
+++ b/build_oui.py
@@ -47,7 +47,7 @@ def build(setup_kwargs: dict[str, Any]) -> None:
 
 
 def _regenerate_ouis_requests() -> None:
-    import requests  # type: ignore
+    import requests
 
     resp = requests.get("https://standards-oui.ieee.org/oui.txt", timeout=20)
     resp.raise_for_status()


### PR DESCRIPTION
## Summary

The pre-commit autoupdate bumps mypy, and the newer mypy resolves the requests import on its own, so the `# type: ignore` on the requests import in build_oui.py is now flagged as an unused ignore and fails lint; this removes it.

## Details

Drops the obsolete `# type: ignore` from `import requests` in build_oui.py; no behavior change, just unblocks the mypy hook.
