### PR TITLE
chore: add types-requests stub for mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,4 +54,4 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
-        additional_dependencies: []
+        additional_dependencies: [types-requests]


### PR DESCRIPTION
## Summary

PR #72 removed the type ignore on the requests import, but the mypy pre-commit hook runs with no extra dependencies, so requests is now untyped and mypy fails with import-untyped on main; this adds the types-requests stub to the hook so requests resolves cleanly.

## Details

Adds types-requests to the mypy hook additional_dependencies; this works with both the current mypy and the newer mypy from the pre-commit autoupdate, since the stub is present in both, so no inline ignore is needed.
