### PR TITLE
ci: bump python-semantic-release to v9.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: git switch -C "$BRANCH"
       - name: Test release
-        uses: python-semantic-release/python-semantic-release@v9.1.0
+        uses: python-semantic-release/python-semantic-release@v9.21.0
         with:
           root_options: --noop
 
@@ -124,7 +124,7 @@ jobs:
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
-        uses: python-semantic-release/python-semantic-release@v9.1.0
+        uses: python-semantic-release/python-semantic-release@v9.21.0
         id: release
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The release-dry-run job fails because python-semantic-release v9.1.0 is a Docker action whose old base image no longer builds (the apt bullseye-backports step errors); this bumps the pin to v9.21.0, which is what aiozoneinfo and zlib-fast already use and whose dry-run passes.

## Details

Bumps both the dry-run and release steps from v9.1.0 to v9.21.0; the root_options --noop dry-run invocation is unchanged, so behavior stays the same.
